### PR TITLE
No opengl interop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -350,5 +350,6 @@ MigrationBackup/
 .ionide/
 
 doc/html/*
+doc/latex/*
 out/*
 CMakeSettings.json

--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ See [here](https://drive.google.com/file/d/1WKryW56hkotbfvl1B7s-fkTOKb_MrOiO/vie
 * *Tab*; Go to the next (and only) frame
 * Move around with mouse, zoom with mouse wheel
 * *View->Measure*; enter measure mode
-* Mouse click; Creates a red point and shows camera coordinates and 3D coordiantes in status bar 
+* Mouse click; Creates a red point and shows camera coordinates and 3D coordiantes in status bar. Note that the Z coordinate is defined as distance to viewer, not height from the ground. A smaller value thus has a higher altitude from the ground. 

--- a/src/IconicMeasureCommon/ImageCanvas.cpp
+++ b/src/IconicMeasureCommon/ImageCanvas.cpp
@@ -38,6 +38,17 @@ void ImageCanvas::SetCurrent() {
 		if (ret != GLEW_OK) {
 			wxLogError("Could not initialize glewInit. Error: %s (code: %d)", wxString(glewGetErrorString(ret)), static_cast<int>(ret));
 		}
+
+		bool bHasOpenGL = true; // ToDo: Evaluate if GPU context has OpenGL/OpenCL interoperability and set flag accordingly
+		if (!bHasOpenGL) {
+			// We never get here now - it is only for testing
+			// Test using GPU context without OpenGL/OpenCL interoperability
+			GpuContext::SetUseOpenGL(false);
+			std::vector<GpuContext::OpenCLDevice> vDevices;
+			GpuContext::GetDevices(vDevices);
+			GpuContext* gpu = GpuContext::Set(vDevices[0], 0); 
+		}
+
 		glDisable(GL_LIGHTING);
 		glClearColor(0.0, 0.0, 0.0, 1.0f);
 		glColorMaterial(GL_FRONT_AND_BACK, GL_EMISSION);

--- a/src/IconicMeasureCommon/ImageCanvas.cpp
+++ b/src/IconicMeasureCommon/ImageCanvas.cpp
@@ -120,6 +120,8 @@ void ImageCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
 	PaintGL();
 
 	DrawMeasuredGeometries();
+
+	wxGLCanvas::SwapBuffers();
 }
 
 void ImageCanvas::DrawMeasuredGeometries() {
@@ -133,8 +135,6 @@ void ImageCanvas::DrawMeasuredGeometries() {
 	}
 	glEnd(); 
 	glPopAttrib();	// Resets color
-
-	wxGLCanvas::SwapBuffers();
 }
 
 void ImageCanvas::OnIdle(wxIdleEvent&) {


### PR DESCRIPTION
Added code to force GPU context without OpenGL/OpenCL interop for testing, see [this issue](https://github.com/I-CONIC-Vision-AB/iconic-api/issues/118).