### PR TITLE
Add rendering coordinates to Shape struct

### DIFF
--- a/include/IconicMeasureCommon/Geometry.h
+++ b/include/IconicMeasureCommon/Geometry.h
@@ -40,6 +40,7 @@ namespace iconic {
 
 			ShapeType type;
 			Polygon3DPtr dataPointer;
+			std::vector<boost::compute::float2_> renderCoordinates;
 
 			Shape(ShapeType t, Polygon3DPtr ptr) {
 				color = Color { 255, 0, 0, 255 };

--- a/include/IconicMeasureCommon/ImageCanvas.h
+++ b/include/IconicMeasureCommon/ImageCanvas.h
@@ -67,10 +67,10 @@ namespace iconic {
 		 * Uses "old style" direct commands and is thus intended only for relatively few objects.
 		 * The alternative is to create OpenGL enabled GpuBuffer:s for vertexes and colors and use ImageGLBase::SetVertexBuffers.
 		 * 
-		 * @param polygon Polygon to be drawn
+		 * @param coordinates The image-coordinates of the polygon that is to be drawn
 		 * @param color Color of polygon
 		*/
-		virtual void DrawMeasuredPolygon(iconic::Geometry::Polygon3DPtr polygon, iconic::Geometry::Color color);
+		virtual void DrawMeasuredPolygon(std::vector<boost::compute::float2_> coordinates, iconic::Geometry::Color color);
 
 		/**
 		 * @brief Called when window is resized

--- a/include/IconicMeasureCommon/MeasureHandler.h
+++ b/include/IconicMeasureCommon/MeasureHandler.h
@@ -112,7 +112,7 @@ namespace iconic {
 		 * @param p The point to be added
 		 * @return True on success, false if add operation fails. May be caused by unreasonable geometry
 		*/
-		bool AddPointToSelectedShape(iconic::Geometry::Point3D p);
+		bool AddPointToSelectedShape(iconic::Geometry::Point3D p, boost::compute::float2_ imgP);
 
 		/**
 		 * @brief Handles finished measurement so that new measurements are added to shapes and altered shapes are altered

--- a/src/IconicMeasureCommon/ImageCanvas.cpp
+++ b/src/IconicMeasureCommon/ImageCanvas.cpp
@@ -152,27 +152,27 @@ void ImageCanvas::OnPaint(wxPaintEvent& WXUNUSED(event))
 	for (const iconic::Geometry::Shape shape : this->mHandler.GetShapes()) {
 		switch (shape.type) {
 		case iconic::Geometry::ShapeType::PolygonShape:
-			DrawMeasuredPolygon(shape.dataPointer, shape.color);
+			DrawMeasuredPolygon(shape.renderCoordinates, shape.color);
 			break;
 		case iconic::Geometry::ShapeType::VectorTrainShape:
 			//TODO: Implement VectorTrainShape
 			break;
 		}
 	}
-
+	DrawMeasuredGeometries();
 
 	wxGLCanvas::SwapBuffers();
 }
 
-void ImageCanvas::DrawMeasuredPolygon(iconic::Geometry::Polygon3DPtr polygon, iconic::Geometry::Color color) {
+void ImageCanvas::DrawMeasuredPolygon(std::vector<boost::compute::float2_> coordinates, iconic::Geometry::Color color) {
 	// Draw the measured points
 	glPushAttrib(GL_CURRENT_BIT); // Apply color until pop
 	glColor3ub(color.red, color.green, color.blue);		  // Color of geometry
-	glPointSize(GetPointSize());
+	glPointSize(10.f);//GetPointSize()
 	glBegin(GL_LINE_LOOP);
-	for (const iconic::Geometry::Point3D p : polygon.get()->outer())
+	for (const boost::compute::float2_& p : coordinates)
 	{
-		glVertex2f(p.get<0>(), p.get<1>());
+		glVertex2f(p.x, p.y);
 	}
 	glEnd();
 	glPopAttrib(); // Resets color
@@ -183,7 +183,7 @@ void ImageCanvas::DrawMeasuredGeometries()
 	// Draw the measured points
 	glPushAttrib(GL_CURRENT_BIT); // Apply color until pop
 	glColor3ub(255, 0, 0);		  // Color of geometry
-	glPointSize(GetPointSize());
+	glPointSize(10.f);//GetPointSize()
 	glBegin(GL_POINTS);
 	for (const boost::compute::float2_& p : cvMeasurements)
 	{
@@ -322,6 +322,7 @@ void ImageCanvas::MouseMeasure(wxMouseEvent& event)
 		ProcessWindowEvent(event);
 	}
 	if (event.RightUp()) {
+		cvMeasurements.clear();
 		MeasureEvent event(MEASURE_POINT, GetId(), -1, -1, MeasureEvent::EAction::FINISHED);
 		event.SetEventObject(this);
 		ProcessWindowEvent(event);

--- a/src/IconicMeasureCommon/MeasureHandler.cpp
+++ b/src/IconicMeasureCommon/MeasureHandler.cpp
@@ -186,12 +186,13 @@ void MeasureHandler::GetImageSize(size_t& width, size_t& height)
 	height = cGeometry.cImageSize[1];
 }
 
-bool MeasureHandler::AddPointToSelectedShape(iconic::Geometry::Point3D p) {
+bool MeasureHandler::AddPointToSelectedShape(iconic::Geometry::Point3D p, boost::compute::float2_ imgP) {
 	// If this is a brand new shape, instantiate it
 	if (!this->selectedShape) {
 		this->selectedShape = boost::shared_ptr<iconic::Geometry::Shape>(new iconic::Geometry::Shape(iconic::Geometry::ShapeType::PolygonShape, cGeometry.CreatePolygon3D(1)));
 	}
 	this->selectedShape->dataPointer.get()->outer().push_back(p);
+	this->selectedShape->renderCoordinates.push_back(imgP);
 
 	return true; // Temporary solution
 }

--- a/src/IconicMeasureCommon/VideoPlayerFrame.cpp
+++ b/src/IconicMeasureCommon/VideoPlayerFrame.cpp
@@ -663,10 +663,10 @@ void VideoPlayerFrame::OnMeasuredPoint(MeasureEvent& e)
 		}
 
 		// Adds the point to the current shape object
-		cpHandler.get()->AddPointToSelectedShape(objectPt);
+		cpHandler.get()->AddPointToSelectedShape(objectPt, boost::compute::float2_(x,y));
 
 		// Print out in status bar of application
-		wxLogStatus("image=[%.4f %.4f], object={%.4lf %.4lf %.4lf]", x, y, objectPt.get<0>(), objectPt.get<1>(), objectPt.get<2>());
+		wxLogStatus("image=[%.4f %.4f], object={%.4lf %.4lf %.4lf}", x, y, objectPt.get<0>(), objectPt.get<1>(), objectPt.get<2>());
 		break;
 	case MeasureEvent::EAction::FINISHED:
 		cpHandler.get()->HandleFinishedMeasurement();


### PR DESCRIPTION
Löser problemet med förlorade renderingskoordinater då koordinaterna byter koordinatsystem genom att spara renderingskoordinater vid sidan av beräkningskoordinaterna. Bör mergeas in i implement-measure om ingen ser något problem med lösningen.