### PR TITLE
Turn rendercoordinates into a polygon

### DIFF
--- a/include/IconicMeasureCommon/Geometry.h
+++ b/include/IconicMeasureCommon/Geometry.h
@@ -40,9 +40,9 @@ namespace iconic {
 
 			ShapeType type;
 			Polygon3DPtr dataPointer;
-			std::vector<boost::compute::float2_> renderCoordinates;
+			PolygonPtr renderCoordinates;
 
-			Shape(ShapeType t, Polygon3DPtr ptr) {
+			Shape(ShapeType t, Polygon3DPtr ptr, PolygonPtr renderPtr) {
 				color = Color { 255, 0, 0, 255 };
 				length = -1;
 				area = -1;
@@ -50,6 +50,7 @@ namespace iconic {
 
 				type = t;
 				dataPointer = ptr;
+				renderCoordinates = renderPtr;
 			}
 		};
 

--- a/include/IconicMeasureCommon/ImageCanvas.h
+++ b/include/IconicMeasureCommon/ImageCanvas.h
@@ -70,7 +70,7 @@ namespace iconic {
 		 * @param coordinates The image-coordinates of the polygon that is to be drawn
 		 * @param color Color of polygon
 		*/
-		virtual void DrawMeasuredPolygon(std::vector<boost::compute::float2_> coordinates, iconic::Geometry::Color color);
+		virtual void DrawMeasuredPolygon(Geometry::PolygonPtr coordinates, iconic::Geometry::Color color);
 
 		/**
 		 * @brief Called when window is resized

--- a/include/IconicMeasureCommon/MeasureHandler.h
+++ b/include/IconicMeasureCommon/MeasureHandler.h
@@ -112,7 +112,7 @@ namespace iconic {
 		 * @param p The point to be added
 		 * @return True on success, false if add operation fails. May be caused by unreasonable geometry
 		*/
-		bool AddPointToSelectedShape(iconic::Geometry::Point3D p, boost::compute::float2_ imgP);
+		bool AddPointToSelectedShape(iconic::Geometry::Point3D p, Geometry::Point imgP);
 
 		/**
 		 * @brief Handles finished measurement so that new measurements are added to shapes and altered shapes are altered
@@ -124,7 +124,7 @@ namespace iconic {
 		 * @param p the point of which the to be selected polygon is placed
 		 * @return True on success, false if a shape cannot be selected. 
 		*/
-		bool SelectPolygonFromCoordinates(boost::compute::float2_ p);
+		bool SelectPolygonFromCoordinates(Geometry::Point p);
 
 		/**
 		 * @brief Returns the list of shapes

--- a/src/IconicMeasureCommon/ImageCanvas.cpp
+++ b/src/IconicMeasureCommon/ImageCanvas.cpp
@@ -164,15 +164,15 @@ void ImageCanvas::OnPaint(wxPaintEvent& WXUNUSED(event))
 	wxGLCanvas::SwapBuffers();
 }
 
-void ImageCanvas::DrawMeasuredPolygon(std::vector<boost::compute::float2_> coordinates, iconic::Geometry::Color color) {
+void ImageCanvas::DrawMeasuredPolygon(Geometry::PolygonPtr coordinates, iconic::Geometry::Color color) {
 	// Draw the measured points
 	glPushAttrib(GL_CURRENT_BIT); // Apply color until pop
 	glColor3ub(color.red, color.green, color.blue);		  // Color of geometry
 	glPointSize(10.f);//GetPointSize()
 	glBegin(GL_LINE_LOOP);
-	for (const boost::compute::float2_& p : coordinates)
+	for (const Geometry::Point& p : coordinates->outer())
 	{
-		glVertex2f(p.x, p.y);
+		glVertex2f(p.get<0>(), p.get<1>());
 	}
 	glEnd();
 	glPopAttrib(); // Resets color

--- a/src/IconicMeasureCommon/VideoPlayerFrame.cpp
+++ b/src/IconicMeasureCommon/VideoPlayerFrame.cpp
@@ -663,7 +663,7 @@ void VideoPlayerFrame::OnMeasuredPoint(MeasureEvent& e)
 		}
 
 		// Adds the point to the current shape object
-		cpHandler.get()->AddPointToSelectedShape(objectPt, boost::compute::float2_(x,y));
+		cpHandler.get()->AddPointToSelectedShape(objectPt, Geometry::Point(x,y));
 
 		// Print out in status bar of application
 		wxLogStatus("image=[%.4f %.4f], object={%.4lf %.4lf %.4lf}", x, y, objectPt.get<0>(), objectPt.get<1>(), objectPt.get<2>());
@@ -672,7 +672,7 @@ void VideoPlayerFrame::OnMeasuredPoint(MeasureEvent& e)
 		cpHandler.get()->HandleFinishedMeasurement();
 		break;
 	case MeasureEvent::EAction::SELECT:
-		cpHandler.get()->SelectPolygonFromCoordinates(boost::compute::float2_(x, y));
+		cpHandler.get()->SelectPolygonFromCoordinates(Geometry::Point(x, y));
 		break;
 	}
 


### PR DESCRIPTION
Minskar konverteringsoverhead genom att lagra renderingskoordinater som en polygon. Uppdaterar inte något i relation till färgerna då jag upptäckte att detta är byggt på en relativt gammal branch som fortfarande implementerar ImageCanvas::cvMeasurements. Renderingsrelaterat får fixas vi merge in i implement-measure.