### PR TITLE
Add different point adding mode for first creation

### DIFF
--- a/include/IconicMeasureCommon/Shape.h
+++ b/include/IconicMeasureCommon/Shape.h
@@ -153,6 +153,11 @@ namespace iconic {
 		wxColour GetColor();
 
 		/**
+		 * @brief Define that the user has finished creating the shape
+		*/
+		void Finish();
+
+		/**
 		* @brief Destructor, removes the wxPanel when the shape is deleted
 		*/
 		virtual ~Shape();
@@ -168,6 +173,7 @@ namespace iconic {
 		int cSelectedPointIndex; //!< The index of the currently selected point
 		ShapeType cType; //!< The type of the shape
 		wxColour cColor; //!< The color of the shape
+		bool cFinished; //!< Defines if the user has finished creation 
 	};
 	typedef boost::shared_ptr<Shape> ShapePtr; //!< Smart pointer to Shape
 

--- a/src/IconicMeasureCommon/MeasureHandler.cpp
+++ b/src/IconicMeasureCommon/MeasureHandler.cpp
@@ -222,7 +222,7 @@ void MeasureHandler::HandleFinishedMeasurement(bool instantiate_new) {
 	if (!cpSelectedShape) {
 		return;
 	}
-
+	cpSelectedShape->Finish();
 	cpSelectedShape->UpdateCalculations(cGeometry);
 
 	iconic::ShapeType previousShapeType = cpSelectedShape->GetType();

--- a/src/IconicMeasureCommon/Shape.cpp
+++ b/src/IconicMeasureCommon/Shape.cpp
@@ -16,6 +16,7 @@ Shape::Shape(ShapeType t, wxColour c) {
 	cColor = c;
 	cSelectedPointIndex = -1;
 	cNextInsertIndex = 0;
+	cFinished = false;
 };
 
 Shape::~Shape() {}
@@ -432,7 +433,7 @@ void LineShape::UpdateCalculations(Geometry& g) {
 	//Code for calculating the heightprofile should go here
 }
 void PolygonShape::UpdateCalculations(Geometry& g) {
-	boost::geometry::correct(*(cRenderCoordinates));
+	//boost::geometry::correct(*(cRenderCoordinates));
 
 	cCoordinates->clear();
 	Geometry::Point3D objectPt;
@@ -510,6 +511,7 @@ int PointShape::GetPossibleIndex(Geometry::Point mousePoint) {
 }
 int LineShape::GetPossibleIndex(Geometry::Point mousePoint) {
 	if (!IsCompleted()) return 0;
+	if (!cFinished) return cNextInsertIndex = GetNumberOfPoints() + 1;
 	int shortestIndex = 0;
 	double shortestDistance = boost::geometry::distance(cRenderCoordinates->at(0), mousePoint);
 	double currentDistance = 0;
@@ -543,6 +545,7 @@ int LineShape::GetPossibleIndex(Geometry::Point mousePoint) {
 }
 int PolygonShape::GetPossibleIndex(Geometry::Point mousePoint) {
 	if (!IsCompleted()) return 0;
+	if (!cFinished) return cNextInsertIndex = GetNumberOfPoints() - 1;
 	int shortestIndex = 0;
 	double shortestDistance = boost::geometry::distance(cRenderCoordinates->outer().at(0), mousePoint);
 	double currentDistance = 0;
@@ -633,3 +636,5 @@ void PolygonShape::SetDrawMode(bool bPolygon, bool bLines, bool bPoints) {
 ShapeType Shape::GetType() { return cType; }
 
 wxColour Shape::GetColor() { return cColor; }
+
+void Shape::Finish() { cFinished = true; }


### PR DESCRIPTION
Based on feedback from client, adding points to the lineshape and polygonshape now functions differently while the user is first creating them.